### PR TITLE
add warning when shared identifier takes too long

### DIFF
--- a/lib/Identifier.luau
+++ b/lib/Identifier.luau
@@ -27,9 +27,15 @@ function Identifier.Shared(Name: string)
 				return Id
 			end
 		else
+			local delayWarn = task.delay(5, function()
+				warn(`Yielded while initializing identifier: {Name}. It may not exist on the server!`)
+			end)
+
 			while not Remote:GetAttribute(Name) do
 				Remote.AttributeChanged:Wait()
 			end
+
+			task.cancel(delayWarn)
 
 			return Remote:GetAttribute(Name)
 		end


### PR DESCRIPTION
The current silent yield behaviour can make debugging a pain after a refactor involving events - it's easy to forget something and end up with a headache figuring out why your code is yielding.

I think 5 seconds is an adequate timeout but it could possibly be increased a bit to guarantee no false positives.