### PR TITLE
Add missing pcall to Event Server listener

### DIFF
--- a/docs/2.0/SharedSignalEvent.md
+++ b/docs/2.0/SharedSignalEvent.md
@@ -4,13 +4,13 @@ SharedEvents are built on the same backend networking as regular events. However
 Unlike [SharedEvents](SharedEvent), SharedSignalEvents may have any number of listeners set.
 
 ## OnServer <Badge type="tip" text="Server"></Badge>
-Sets the server callback.
+Adds a server callback, returning a disconnect function.
 ```lua
 <T...>(
     Listener: (Player: Player, T...) -> () -- The listener to register
-) -> ()
+) -> (() -> ()) -- Disconnect function
 ```
-This method sets the server callback. Errors if called from the client.
+This method adds a server callback, returning a disconnect function. Errors if called from the client.
 ```lua
 MyEvent:OnServer(function(Player, Argument)
     print(Player, Argument)
@@ -18,13 +18,13 @@ end)
 ```
 
 ## OnClient <Badge type="warning" text="Client"></Badge>
-Sets the client callback.
+Adds a client callback, returning a disconnect function.
 ```lua
 <T...>(
     Listener: (T...) -> () -- The listener to register
-) -> ()
+) -> (() -> ()) -- Disconnect function
 ```
-This method sets the client callback. Errors if called from the server.
+This method adds a client callback, returning a disconnect function. Errors if called from the server.
 ```lua
 MyEvent:OnClient(function(Argument)
     print(Argument)

--- a/docs/guide/events/sharedevent.md
+++ b/docs/guide/events/sharedevent.md
@@ -3,7 +3,7 @@ Shared Events are simply a different way of using Events. They both use the same
 
 They have the major benefit of not needing to explicitly call `Event:Server` or `Event:Client` before being usable. Both your server and client code can simply require them and start using them.
 
-There are two types of Shared Events: The default `SharedEvent`, and the Signal-based `SharedSignalEvent`. By default, Shared Events only allow you to set one callback function, but Shared Signal Events allow you to have any number of callbacks.
+There are two types of Shared Events: The default [SharedEvent](/2.0/SharedEvent), and the Signal-based [SharedSignalEvent](/2.0/SharedSignalEvent). By default, Shared Events only allow you to set one callback function, but Shared Signal Events allow you to have any number of callbacks.
 
 This is marginally worse for performance, as it has to use a Signal to fire the callbacks - hence why it is not the default.
 
@@ -72,9 +72,12 @@ end)
 Events.PayloadSignalEvent:OnClient(function(number)
     print("Callback 1", number)
 end)
-Events.PayloadSignalEvent:OnClient(function(number)
+
+local DisconnectFunction = Events.PayloadSignalEvent:OnClient(function(number)
     print("Callback 2", number)
 end)
+
+DisconnectFunction() -- Disconnects the 2nd callback.
 ```
 
 ### Server
@@ -92,9 +95,12 @@ end)
 Events.PayloadSignalEvent:OnServer(function(Player, number)
     print("Callback 1 from", Player, number)
 end)
-Events.PayloadSignalEvent:OnServer(function(Player, number)
+
+local DisconnectFunction = Events.PayloadSignalEvent:OnServer(function(Player, number)
     print("Callback 2 from", Player, number)
 end)
+
+DisconnectFunction() -- Disconnects the 2nd callback.
 ```
 
 ## Firing Events

--- a/lib/Event/Server.luau
+++ b/lib/Event/Server.luau
@@ -82,7 +82,7 @@ end
 local function On<T...>(self: Server<T...>, Callback: (Player, T...) -> ())
 	Net.Server.SetListener(self.Id, function(Player, Args)
 		Spawn(function(self: typeof(self), Player: Player, ...: any)
-			if self.Validate(...) then
+			if pcall(self.Validate, ...) then
 				Callback(Player, ...)
 			end
 		end, self, Player, table.unpack(Args))

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "red-blox/red"
-version = "2.3.0"
+version = "2.3.1"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 license = "MIT"


### PR DESCRIPTION
This was causing empty events to never reach the server, as well as enabling error spam from exploiters if they continually sent incorrectly typed data.