### PR TITLE
Add error trace to Functions with xpcall

### DIFF
--- a/Test/Client/Client.client.luau
+++ b/Test/Client/Client.client.luau
@@ -3,6 +3,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 function TestEvents()
 	local ComplexFunction = require(ReplicatedStorage.ComplexFunction)
 	local EmptyFunction = require(ReplicatedStorage.EmptyFunction)
+	local ErrorFunction = require(ReplicatedStorage.ErrorFunction)
 	local SimpleFunction = require(ReplicatedStorage.SimpleFunction)
 
 	local ComplexEvent = require(ReplicatedStorage.ComplexEvent):Client()
@@ -40,6 +41,7 @@ function TestEvents()
 	print(ComplexFunction:Call({ one = { "String Literal", 123 }, two = { 123, "String Literal" } }, "hi", 12):Await())
 	print(SimpleFunction:Call(123):Await())
 	print(EmptyFunction:Call():Await())
+	print(ErrorFunction:Call():Await())
 
 	task.wait(0.5)
 
@@ -91,4 +93,5 @@ function TestSharedEvents()
 	SharedEvents.Ready:FireServer()
 end
 
-TestSharedEvents()
+TestEvents()
+-- TestSharedEvents()

--- a/Test/Server/Server.server.luau
+++ b/Test/Server/Server.server.luau
@@ -4,6 +4,7 @@ function TestEvents()
 	local ComplexFunction = require(ReplicatedStorage.ComplexFunction)
 	local SimpleFunction = require(ReplicatedStorage.SimpleFunction)
 	local EmptyFunction = require(ReplicatedStorage.EmptyFunction)
+	local ErrorFunction = require(ReplicatedStorage.ErrorFunction)
 
 	local ComplexEvent = require(ReplicatedStorage.ComplexEvent):Server()
 	local SimpleEvent = require(ReplicatedStorage.SimpleEvent):Server()
@@ -29,6 +30,11 @@ function TestEvents()
 		print("EmptyFunction", Player)
 
 		return
+	end)
+
+	ErrorFunction:SetCallback(function(Player)
+		assert(1 == 2, "Assert failed.")
+		return ""
 	end)
 
 	print("Registering Event Listeners")
@@ -166,4 +172,5 @@ function TestSharedEvents()
 	end)
 end
 
-TestSharedEvents()
+TestEvents()
+-- TestSharedEvents()

--- a/Test/Shared/ErrorFunction.luau
+++ b/Test/Shared/ErrorFunction.luau
@@ -1,0 +1,6 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Guard = require(ReplicatedStorage.Packages.Guard)
+local Red = require(ReplicatedStorage.Packages.Red)
+return Red.Function("ErrorFunction", function() end, function(Ret1)
+	return Guard.String(Ret1)
+end)

--- a/lib/Function.luau
+++ b/lib/Function.luau
@@ -19,11 +19,13 @@ export type Function<A..., R...> = {
 	end)),
 }
 
-local function Trace(err)
+local function Trace(err: unknown, ...)
 	-- Return at 2nd level so the traceback starts at the function, not here.
-	local trace = debug.traceback(err, 2)
-	warn(`Red Function error: {trace}`)
-	return trace
+	if typeof(err) == "string" then
+		local trace = debug.traceback(err, 2)
+		warn(`Red Function error: {trace}`)
+	end
+	return err, ...
 end
 
 local function SetCallback<A..., R...>(self: Function<A..., R...>, Callback: (Player, A...) -> R...)

--- a/lib/Function.luau
+++ b/lib/Function.luau
@@ -19,6 +19,13 @@ export type Function<A..., R...> = {
 	end)),
 }
 
+local function Trace(err)
+	-- Return at 2nd level so the traceback starts at the function, not here.
+	local trace = debug.traceback(err, 2)
+	warn(`Red Function error: {trace}`)
+	return trace
+end
+
 local function SetCallback<A..., R...>(self: Function<A..., R...>, Callback: (Player, A...) -> R...)
 	assert(RunService:IsServer(), "Cannot set callback to function on client")
 
@@ -31,7 +38,7 @@ local function SetCallback<A..., R...>(self: Function<A..., R...>, Callback: (Pl
 
 		Spawn(function(Player: Player, CallId: string, ...: any)
 			if pcall(self.Validate, ...) then
-				Net.Server.SendCallReturn(Player, CallId, table.pack(pcall(Callback, Player, ...)))
+				Net.Server.SendCallReturn(Player, CallId, table.pack(xpcall(Callback, Trace, Player, ...)))
 			end
 		end, Player, CallId, unpack(Args))
 	end)


### PR DESCRIPTION
Not sure what your stance on this is, but I personally think it's good for DX so I figured I'd make a PR and you can decide whether to merge or close.
There's no pressure at all to respond quickly - I know you're preoccupied with thinking about zap so feel free to come back to this later.
The code isn't particularly long so there's nothing lost if it isn't merged.

For reference, evaera's promise library uses xpcall for its stack traces so it's a battle tested method for this sort of thing.